### PR TITLE
WebSocket接続時にElasticCacheにConnectionIDを登録する

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -6,4 +6,4 @@ deploy:
 	sam build
 	cd .aws-sam/build
 	sam package --output-template-file packaged.yaml --s3-bucket sam-simple-chat
-    sam deploy --template-file packaged.yaml --stack-name sam-simple-chat --capabilities CAPABILITY_IAM
+	sam deploy --template-file packaged.yaml --stack-name sam-simple-chat --capabilities CAPABILITY_IAM

--- a/app/connections/go.mod
+++ b/app/connections/go.mod
@@ -1,5 +1,9 @@
-require github.com/aws/aws-lambda-go v1.13.3
+require (
+	github.com/aws/aws-lambda-go v1.13.3
+	github.com/gomodule/redigo v2.0.0+incompatible // indirect
+	github.com/soveran/redisurl v0.0.0-20180322091936-eb325bc7a4b8
+)
 
-module hello-world
+module connections
 
 go 1.13

--- a/app/connections/go.sum
+++ b/app/connections/go.sum
@@ -3,9 +3,14 @@ github.com/aws/aws-lambda-go v1.13.3 h1:SuCy7H3NLyp+1Mrfp+m80jcbi9KYWAs9/BXwppwR
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
+github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/gomodule/redigo/redis v0.0.0-do-not-use h1:J7XIp6Kau0WoyT4JtXHT3Ei0gA1KkSc6bc87j9v9WIo=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/soveran/redisurl v0.0.0-20180322091936-eb325bc7a4b8 h1:rUK5c0TsYfhfhA5otEUzV46qjN8C2EoNPlyroy9A8Nk=
+github.com/soveran/redisurl v0.0.0-20180322091936-eb325bc7a4b8/go.mod h1:FVJ8jbHu7QrNFs3bZEsv/L5JjearIAY9N0oXh2wk+6Y=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=

--- a/app/connections/main.go
+++ b/app/connections/main.go
@@ -1,48 +1,28 @@
 package main
 
 import (
-	"errors"
+    "errors"
 	"fmt"
-	"io/ioutil"
-	"net/http"
+    "os"
 
-	"github.com/aws/aws-lambda-go/events"
+    "github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+    "github.com/soveran/redisurl"
 )
 
 var (
-	// DefaultHTTPGetAddress Default Address
-	DefaultHTTPGetAddress = "https://checkip.amazonaws.com"
-
-	// ErrNoIP No IP found in response
-	ErrNoIP = errors.New("No IP in HTTP response")
-
 	// ErrNon200Response non 200 status code in response
 	ErrNon200Response = errors.New("Non 200 Response found")
 )
 
-func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	resp, err := http.Get(DefaultHTTPGetAddress)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
-	}
+func handler(request events.APIGatewayWebsocketProxyRequest) (events.APIGatewayProxyResponse, error) {
+    cid := request.RequestContext.ConnectionID
+    var_dump(cid)
 
-	if resp.StatusCode != 200 {
-		return events.APIGatewayProxyResponse{}, ErrNon200Response
-	}
-
-	ip, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
-	}
-    var_dump(resp.Body)
-
-	if len(ip) == 0 {
-		return events.APIGatewayProxyResponse{}, ErrNoIP
-	}
+	res := SaveUser(cid)
+	var_dump(res)
 
 	return events.APIGatewayProxyResponse{
-		Body:       fmt.Sprintf("Hello, %v", string(ip)),
 		StatusCode: 200,
 	}, nil
 }
@@ -55,4 +35,28 @@ func var_dump(v ...interface{}) {
     for _, vv := range(v) {
         fmt.Printf("%#v\n", vv)
     }
+}
+
+// SaveUser ユーザを保存する
+func SaveUser(cid string) interface{} {
+    ep := os.Getenv("CacheEndPoint")
+    conn, err := redisurl.ConnectToURL("telnet://" + ep)
+    if err != nil {
+        fmt.Println(err)
+        panic(err)
+    }
+
+    val, err := conn.Do("SET", "users", cid, "NX", "EX", "120")
+    if err != nil {
+        fmt.Println(err)
+        panic(err)
+    }
+
+    // 存在判定
+    if val == nil {
+        fmt.Println("既にオンラインです。")
+        panic(err)
+    }
+
+    return val
 }

--- a/app/template.yaml
+++ b/app/template.yaml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >
   app
-  
+
   Sample SAM Template for app
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
@@ -62,7 +62,13 @@ Resources:
       Tracing: Active # https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
-          PARAM1: VALUE
+          CacheEndPoint: !ImportValue MojiChatCacheEndPoint
+      VpcConfig:
+        SecurityGroupIds:
+          - !ImportValue DefaultSGId
+        SubnetIds:
+          - !ImportValue MojiChatVPC-SubnetPrivate
+
   OnConnectPermission:
     Type: AWS::Lambda::Permission
     DependsOn:

--- a/infrastructure/vpc.yaml
+++ b/infrastructure/vpc.yaml
@@ -1,10 +1,17 @@
 AWSTemplateFormatVersion: '2010-09-09'
 
 Parameters:
+  # SSH用キーペアの指定
+  KeyPair:
+    Description: KeyPair Name
+    Type: AWS::EC2::KeyPair::KeyName
   # SSHを許可するIP
   MyIP:
     Description: My IP
     Type:  String
+  AmiId:
+    Description: AMI ID
+    Type: AWS::EC2::Image::Id
 
 Resources:
   MojiChatVPC:
@@ -89,6 +96,19 @@ Resources:
         FromPort: '22'
         ToPort: '22'
         CidrIp: !Ref MyIP
+
+  Bastion:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType: 't2.micro'
+      SecurityGroupIds:
+        - !GetAtt MojiChatSecurityGroup.GroupId
+      SubnetId: !Ref FrontendSubnet
+      ImageId: !Ref AmiId
+      KeyName: !Ref KeyPair
+      Tags:
+        - Key: Name
+          Value: Bastion
 
   CacheSubnetGroup:
     Type: AWS::ElastiCache::SubnetGroup

--- a/infrastructure/vpc.yaml
+++ b/infrastructure/vpc.yaml
@@ -12,6 +12,11 @@ Parameters:
   AmiId:
     Description: AMI ID
     Type: AWS::EC2::Image::Id
+  # VPCのデフォルトSGのID
+  DefaultSGId:
+    Description: VPC DefaultSGId
+    Type:  String
+    Default: sg-084199ab9beac7266
 
 Resources:
   MojiChatVPC:
@@ -147,3 +152,7 @@ Outputs:
     Value: !Ref SubnetPrivate
     Export:
       Name: MojiChatVPC-SubnetPrivate
+  DefaultSGId:
+    Value: !Ref DefaultSGId
+    Export:
+      Name: DefaultSGId

--- a/parameters/env.sample
+++ b/parameters/env.sample
@@ -1,1 +1,3 @@
-MyIP=IP/32
+MyIP=SSHするIP
+AmiId=利用するAMIのID
+KeyPair=SSHで利用するキー名


### PR DESCRIPTION
### 概要
WebSocket接続時にConnectionIDを登録し、のちのアクションで使うようにする.
[サンプル](https://github.com/aws-samples/simple-websockets-chat-app)ではDynamoDBを使っているが、使い慣れていてかつVPCLambdaを試せるElasticCacheを利用する.